### PR TITLE
Update proxy_pass to use HTTPS for Splatoon3 Tracker

### DIFF
--- a/nginx/splatoon3-tracker
+++ b/nginx/splatoon3-tracker
@@ -34,7 +34,7 @@ server {
 
 	# Proxy設定
 	location / {
-		proxy_pass http://15.152.160.213:5000;
+		proxy_pass https://15.152.160.213:5000;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Change the proxy_pass configuration to use HTTPS for improved security in the Splatoon3 Tracker.