### PR TITLE
Update deployment script to use HTTPS for Nagiyu.Web

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,7 +129,7 @@ jobs:
         port: ${{ secrets.AWS_SSH_PORT }}
         script: |
           cd /home/ec2-user/splatoon3-tracker/bin
-          nohup dotnet Nagiyu.Web.dll --urls "http://0.0.0.0:5000" > /home/ec2-user/output.log 2>&1 &
+          nohup dotnet Nagiyu.Web.dll --urls "https://0.0.0.0:5000" > /home/ec2-user/output.log 2>&1 &
 
     - name: Close SecurityGroup
       run: aws ec2 revoke-security-group-ingress --group-id ${{ secrets.EC2_SECURITY_GROUP_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32


### PR DESCRIPTION
Change the deployment script to use HTTPS instead of HTTP for the Nagiyu.Web application.