### PR TITLE
Update Nginx proxy_pass URL for Splatoon 3 tracker

### DIFF
--- a/nginx/splatoon3-tracker
+++ b/nginx/splatoon3-tracker
@@ -34,7 +34,7 @@ server {
 
 	# Proxy設定
 	location / {
-		proxy_pass https://splatoon3-tracker-1098142135.ap-northeast-3.elb.amazonaws.com;
+		proxy_pass https://Splatoon3TrackerALB-1227167984.ap-northeast-3.elb.amazonaws.com;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Change the proxy_pass URL in the Nginx configuration to point to the updated Splatoon 3 tracker endpoint.